### PR TITLE
Fix respondWith behavior by returning a Promise

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,15 +1,17 @@
 import { log } from './sentry'
 
 addEventListener('fetch', event => {
-  event.respondWith(async () => {
-    try {
-      const res = await handleRequest(event.request)
-      return res
-    } catch (e) {
-      event.waitUntil(log(e, event.request))
-      return new Response(e.message || 'An error occurred!', { status: e.statusCode || 500 })
-    }
-  })
+  event.respondWith(
+    (async () => {
+      try {
+        const res = await handleRequest(event.request)
+        return res
+      } catch (e) {
+        event.waitUntil(log(e, event.request))
+        return new Response(e.message || 'An error occurred!', { status: e.statusCode || 500 })
+      }
+    })(),
+  )
 })
 
 async function handleRequest(request) {


### PR DESCRIPTION
This fixes an issue with deploying this project where `respondWith` expects a `Promise` argument - I've made this change and deployed it to confirm that it fixes. Super excited about this template, thanks again!